### PR TITLE
style: prevent template Q's from auto-populating

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,23 +8,25 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **Steps to reproduce**
+<!--
 Please, describe in as many details how the bug occured and what steps did you make to experience it.
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
 
 **Expected behavior**
-A clear description of what you expected to happen.
+<!-- A clear description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Environment (please complete the following information):**
- - Application Version [e.g. 22] (read this information in About window).
+<!--  - Application Version [e.g. 22] (read this information in About window). -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
This change should prevent questions from `.github/ISSUE_TEMPLATE/bug_report.md` from automatically showing up in the text of a new issue, saving issue reporters time since they shouldn't have to manually erase each section's instructions after this change.